### PR TITLE
MongoAdapter now implement BatchAdapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,5 +37,17 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <version>4.18.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
         <dependency>
             <groupId>org.casbin</groupId>
             <artifactId>jcasbin</artifactId>
-            <version>1.7.4</version>
+            <version>1.77.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/jim/jcasbin/MongoAdapter.java
+++ b/src/main/java/org/jim/jcasbin/MongoAdapter.java
@@ -7,6 +7,7 @@ import com.mongodb.client.MongoCollection;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
+import org.casbin.jcasbin.model.Assertion;
 import org.casbin.jcasbin.model.Model;
 import org.casbin.jcasbin.persist.Adapter;
 import org.jim.jcasbin.domain.CasbinRule;
@@ -91,7 +92,14 @@ public class MongoAdapter implements Adapter {
     @Override
     public void loadPolicy(Model model) {
         Map<String, ArrayList<ArrayList<String>>> policies = this.loading();
-        policies.keySet().forEach(k -> model.model.get(k.substring(0, 1)).get(k).policy.addAll(policies.get(k)));
+        policies.keySet()
+                .forEach(k -> {
+                    Assertion assertion = model.model.get(k.substring(0, 1)).get(k);
+                    for (ArrayList<String> policy : policies.get(k)) {
+                        assertion.policy.add(policy);
+                        assertion.policyIndex.put(policy.toString(), assertion.policy.size() - 1);
+                    }
+        });
     }
 
     Map<String, ArrayList<ArrayList<String>>> loading() {

--- a/src/main/java/org/jim/jcasbin/MongoAdapter.java
+++ b/src/main/java/org/jim/jcasbin/MongoAdapter.java
@@ -4,12 +4,13 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.DeleteOneModel;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.casbin.jcasbin.model.Assertion;
 import org.casbin.jcasbin.model.Model;
-import org.casbin.jcasbin.persist.Adapter;
+import org.casbin.jcasbin.persist.BatchAdapter;
 import org.jim.jcasbin.domain.CasbinRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +34,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
  * Description:
  */
 
-public class MongoAdapter implements Adapter {
+public class MongoAdapter implements BatchAdapter {
     private static final String DEFAULT_DB_NAME = "casbin";
     private static final String DEFAULT_COL_NAME = "casbin_rule";
     private static final Logger log = LoggerFactory.getLogger(MongoAdapter.class);
@@ -195,5 +196,56 @@ public class MongoAdapter implements Adapter {
     @Override
     public void removeFilteredPolicy(String sec, String ptype, int fieldIndex, String... fieldValues) {
         this.removing(sec, ptype, fieldIndex, fieldValues);
+    }
+
+    /**
+     * addPolicies adds authorization rules to the current policy.
+     *
+     * @param sec         the section, "p" or "g".
+     * @param ptype       the policy type, "p", "p2", .. or "g", "g2", ..
+     * @param rules       the rules, like ((sub, obj, act), (sub, obj, act), ...).
+     */
+    @Override
+    public void addPolicies(String sec, String ptype, List<List<String>> rules) {
+        ArrayList<CasbinRule> rulesOfRules = new ArrayList<>(rules.size());
+        for (List<String> rule : rules) {
+            ArrayList<String> ruleClone = new ArrayList<>(rule);
+            ruleClone.add(0, ptype);
+            for (int i = 0; i < 6 - rule.size(); i++) {
+                ruleClone.add("");
+            }
+            Optional<CasbinRule> casbinRule = fromListRule(ruleClone);
+            casbinRule.ifPresent(rulesOfRules::add);
+        }
+
+        if(!rulesOfRules.isEmpty()) {
+            this.getCollection().insertMany(rulesOfRules);
+        }
+    }
+
+    /**
+     * removePolicies removes authorization rules from the current policy.
+     *
+     * @param sec         the section, "p" or "g".
+     * @param ptype       the policy type, "p", "p2", .. or "g", "g2", ..
+     * @param rules       the rules, like ((sub, obj, act), (sub, obj, act), ...).
+     */
+    @Override
+    public void removePolicies(String sec, String ptype, List<List<String>> rules) {
+        ArrayList<DeleteOneModel<CasbinRule>> deleteRequests = new ArrayList<>();
+        for (List<String> rule : rules) {
+            if (rule.isEmpty()) continue;
+            Document filter = new Document("ptype", ptype);
+            int columnIndex = 0;
+            for (String fieldValue : rule) {
+                if (CasbinRule.hasText(fieldValue)) filter.put("v" + columnIndex, fieldValue);
+                columnIndex++;
+            }
+            deleteRequests.add(new DeleteOneModel<>(filter));
+        }
+
+        if(!deleteRequests.isEmpty()) {
+            this.getCollection().bulkWrite(deleteRequests);
+        }
     }
 }

--- a/src/test/java/org/jim/jcasbin/MongoAdapterTest.java
+++ b/src/test/java/org/jim/jcasbin/MongoAdapterTest.java
@@ -5,8 +5,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.fail;
-
 /**
  * Created with IntelliJ IDEA.
  *
@@ -30,11 +28,6 @@ public class MongoAdapterTest {
         try (AdapterCreator.MongoAdapterCreator creator = new AdapterCreator.MongoAdapterCreator()) {
             adapters.add(creator.create());
             testAdapter(adapters);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
-
-
 }

--- a/src/test/java/org/jim/jcasbin/MongoAdapterTest.java
+++ b/src/test/java/org/jim/jcasbin/MongoAdapterTest.java
@@ -19,6 +19,7 @@ public class MongoAdapterTest {
         for (MongoAdapter a : adapters) {
             MongoAdapterTestSets.testAdapter(a);
             MongoAdapterTestSets.testAddAndRemovePolicy(a);
+            MongoAdapterTestSets.testBatchAddAndRemovePolicies(a);
         }
     }
 


### PR DESCRIPTION
Hello,

MongoAdapter was implementing `org.casbin.jcasbin.persist.Adapter` interface.
For our usecase, we needed to implement `org.casbin.jcasbin.persist.BatchAdapter` interface in order to batch insert/delete commands.

I also upgraded jcasbin dependency to latest version available and fed the model's assertion policyIndex (available since [1.25.0](https://github.com/casbin/jcasbin/releases/tag/v1.25.0)).
And I used flapdoodle embed MongoDB instance in order to run the tests.